### PR TITLE
set package name when publish to npm

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -112,6 +112,7 @@ gulp.task('release', ['release-copy'], async () => {
   const version = await getVersionFromTag();
   if (version) {
     packageInfo.version = version;
+    packageInfo.name = 'ringcentral-widget';
   }
   await fs.writeFile('release/package.json', JSON.stringify(packageInfo, null, 2));
 });


### PR DESCRIPTION
set package name when publish to npm
release to lastest use ringcentral-js-widget
release to npm use ringcentral-widget