### PR TITLE
bugFix/modify messageItem hasEntity property judgement

### DIFF
--- a/packages/ringcentral-widgets/components/MessageItem/index.js
+++ b/packages/ringcentral-widgets/components/MessageItem/index.js
@@ -490,7 +490,8 @@ export default class MessageItem extends Component {
             }
             onViewEntity={onViewContact && this.viewSelectedContact}
             onCreateEntity={onCreateContact && this.createSelectedContact}
-            hasEntity={correspondents.length === 1 && !!correspondentMatches.length && this.state.selected >= 0}
+            hasEntity={correspondents.length === 1 && !!correspondentMatches.length &&
+              this.state.selected >= 0}
             onClickToDial={!isFax ? (onClickToDial && this.clickToDial) : undefined}
             onClickToSms={isVoicemail ? (onClickToSms && this.onClickToSms) : undefined}
             phoneNumber={phoneNumber}


### PR DESCRIPTION
when turn on showContactDisplayPlaceholder property and the number is matched multiple entities, shouldn't show view entity icon when user not select any entity.